### PR TITLE
Fix benchmark group label of dspr_y_position as indicated in README

### DIFF
--- a/unibench/benchmarks_zoo/benchmarks.py
+++ b/unibench/benchmarks_zoo/benchmarks.py
@@ -1424,7 +1424,7 @@ def dspr_x_position(benchmark_name, transform=None, **kwargs):
 
 
 @register_benchmark(
-    "transfer",
+    "vtab",
     {
         "benchmark": "zero-shot",
         "benchmark_type": "reasoning",


### PR DESCRIPTION
Small change to change `dspr_y_position` to `vtab` group as indicated in parent directory's README.